### PR TITLE
fix: Add path to node-eval

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -99,7 +99,7 @@ export async function bundleNRequire(
     try {
       bundle.mod = await loadBundledFile(absPath, bundle.code)
     } catch {
-      bundle.mod = require('node-eval')(bundle.code).default
+      bundle.mod = require('node-eval')(bundle.code, absPath).default
     }
     return bundle
   }


### PR DESCRIPTION
The filename is required to allow imports (e.g. from `node:path`) to work.

 I ran into this bug when using Panda.

Thanks for the awesome library!